### PR TITLE
Fix: Update Sidebar Background Color and Item Styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -69,6 +69,10 @@
     --ring: var(--accent);             /* Accent color for focus rings */
     --radius: 8px;
 
+    /* Custom Sidebar Colors */
+    --sidebar-custom-bg: hsl(180, 89%, 19%);
+    --sidebar-custom-fg: hsl(0, 0%, 95%);
+
     /* New Spacing Variables */
     --space-unit: 4px;
     --space-xs: var(--space-unit);                     /* 4px */

--- a/components/core/navigation/SidebarNav.tsx
+++ b/components/core/navigation/SidebarNav.tsx
@@ -24,18 +24,19 @@ export function SidebarNav({ isCollapsed, setIsCollapsed }: SidebarNavProps) {
   const pathname = usePathname()
 
   return (
-    <div className={cn("bg-card border-r border-border transition-all duration-300 overflow-x-hidden", isCollapsed ? "w-20 min-w-[5rem]" : "w-72 min-w-[18rem]")}>
+    <div className={cn("bg-[var(--sidebar-custom-bg)] border-r border-[hsl(180,89%,25%)] transition-all duration-300 overflow-x-hidden", isCollapsed ? "w-20 min-w-[5rem]" : "w-72 min-w-[18rem]")}>
       <div className="p-4">
         <div className="flex items-center justify-between mb-8">
           {!isCollapsed && (
             <div className="flex items-center space-x-2">
               <div className="w-8 h-8 bg-gradient-to-br from-primary to-accent rounded-lg flex items-center justify-center">
+                {/* Icon color might need adjustment if it clashes with the new gradient on dark sidebar */}
                 <Search className="w-4 h-4 text-white" />
               </div>
-              <span className="text-xl font-semibold text-primary">S-I-K-R-Y</span>
+              <span className="text-xl font-semibold text-[var(--sidebar-custom-fg)]">S-I-K-R-Y</span>
             </div>
           )}
-          <Button variant="ghost" size="sm" onClick={() => setIsCollapsed(!isCollapsed)} className="h-8 w-8 p-0">
+          <Button variant="ghost" size="sm" onClick={() => setIsCollapsed(!isCollapsed)} className="h-8 w-8 p-0 text-[var(--sidebar-custom-fg)]">
             {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
           </Button>
         </div>
@@ -50,8 +51,8 @@ export function SidebarNav({ isCollapsed, setIsCollapsed }: SidebarNavProps) {
                 className={cn(
                   "flex items-center px-3 py-2 rounded-lg text-sm font-medium transition-colors",
                   isActive
-                    ? "bg-primary text-primary-foreground"
-                    : "text-neutral-700 dark:text-neutral-300 hover:bg-muted hover:text-primary",
+                    ? "bg-primary text-primary-foreground" // Active state remains prominent
+                    : "text-[var(--sidebar-custom-fg)]/80 hover:bg-[var(--sidebar-custom-fg)]/10 hover:text-[var(--sidebar-custom-fg)]",
                   isCollapsed && "justify-center",
                 )}
               >


### PR DESCRIPTION
Addresses your feedback regarding sidebar appearance:
- Sets sidebar background to a custom dark teal color (#055757).
- Ensures all text and icons within the sidebar use a light foreground color for high contrast against the new dark background.
- Updates navigation item hover state to be clearly visible on the new background.

Detailed Changes:

1.  **`app/globals.css`:**
    *   Added `--sidebar-custom-bg: hsl(180, 89%, 19%);`
    *   Added `--sidebar-custom-fg: hsl(0, 0%, 95%);`

2.  **`components/core/navigation/SidebarNav.tsx`:**
    *   Changed sidebar container background to `bg-[var(--sidebar-custom-bg)]`.
    *   Updated sidebar title and collapse button icons to use
        `text-[var(--sidebar-custom-fg)]`.
    *   Adjusted sidebar border to `border-[hsl(180,89%,25%)]`.
    *   Updated navigation item link styles:
        *   Default text: `text-[var(--sidebar-custom-fg)]/80`.
        *   Hover state: `hover:bg-[var(--sidebar-custom-fg)]/10 hover:text-[var(--sidebar-custom-fg)]`.
        *   Active state remains `bg-primary text-primary-foreground`.